### PR TITLE
#20: Add syntax highlighting

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
     <link href="css/font-awesome.min.css" rel="stylesheet" />
     <link href="css/bootstrap.min.css" rel="stylesheet" />
     <link href="css/bootstrap-theme.min.css" rel="stylesheet" />
+    <link href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.7.0/styles/vs.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />
 </head>
 <body role="document" class="lighttheme">
@@ -51,6 +52,7 @@
 
     <script src="js/jquery.min.js"></script>
     <script src="js/bootstrap.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.7.0/highlight.min.js"></script>
     <script src="js/site.js"></script>
 </body>
 </html>

--- a/src/js/site.js
+++ b/src/js/site.js
@@ -117,6 +117,13 @@ $(document).ready(function () {
         $('.loaded-content').show();
         $('.loading-overlay').remove();
     }
+    
+    // add syntax highlighting to pre and code blocks after 200ms (to allow dynamic html content to load)
+    setTimeout(function (){
+        $('pre code').each(function(i, block) {
+            hljs.highlightBlock(block);
+        });
+    }, 200);
 
     function runTutorial() {
         var checkboxElem = $($('i.incomplete-check:visible,i.complete-check:visible').first());


### PR DESCRIPTION
I added syntax highlighting with [highlight.js](https://highlightjs.org/) using their Visual Studio-like color theme.

The highlighting is added to code elements inside of pre elements. I know this does not match the current structure of the generated HTML, but this allows users to specify the language used in the snippet and/or not use the highlighting feature by not having a code element. The library does have an automatic language recognition feature, but it seems spotty (particularly with short snippets).

You can easily attach the highlighting functionality to pre elements, but I would highly recommend allowing users some way to specify the language (perhaps in the JSON) to avoid having issues with the language detection feature.